### PR TITLE
Add clean-room agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     ├── lua/autogen/  # Compiled Lua files
     ├── lua/          # Lua source files
     ├── npins/        # Nix package management for v2
+    ├── scripts/      # Development workflow scripts
     ├── tmpl/         # Template files
     └── vim/          # Vim script configurations
 ```
-

--- a/apps.nix
+++ b/apps.nix
@@ -80,6 +80,31 @@ in
         nix flake metadata --json | jq -r '.locks.nodes | keys[]' | grep neotest | xargs -I {} nix flake update {}
       '';
     };
+    clean-room-workspace = mkApp {
+      name = "clean-room-workspace";
+      inputs = with pkgs; [
+        bash
+        coreutils
+        findutils
+        git
+        gnugrep
+        gnused
+      ];
+      script = ''
+        exec ${./v2/scripts/clean-room/clean-room-workspace.sh} "$@"
+      '';
+    };
+    install-clean-room-opencode = mkApp {
+      name = "install-clean-room-opencode";
+      inputs = with pkgs; [
+        bash
+        coreutils
+      ];
+      script = ''
+        export CLEAN_ROOM_SOURCE_DIR="$PWD/v2/scripts/clean-room"
+        exec ${./v2/scripts/clean-room/install-opencode.sh} "$@"
+      '';
+    };
   };
   devShells.default = pkgs.mkShell {
     packages = with pkgs; [

--- a/v2/scripts/clean-room/README.md
+++ b/v2/scripts/clean-room/README.md
@@ -1,0 +1,204 @@
+# Clean-room agent workflow
+
+A clean-room workflow for compatibility / black-box implementation work, driven
+by separate OpenCode sessions through GPT on OpenCode Go
+(`opencode-go/gpt-5.6-luna`). Observation stays in one directory, implementation
+in another, and only a human-reviewed, hash-verified approved package crosses the
+boundary.
+
+This lives under `v2/scripts/clean-room/` and is unrelated to the Neovim plugin
+configuration. Do not wire it into the plugin setup.
+
+```
+v2/scripts/clean-room/
+├── README.md                          # this file
+├── clean-room-workspace.sh            # case lifecycle: init / path / worktree / approve
+├── install-opencode.sh                # symlink the skill + agents into OpenCode config
+├── agents/opencode/
+│   ├── clean-room-orchestrator.md
+│   ├── clean-room-specifier.md
+│   ├── clean-room-implementer.md
+│   └── clean-room-verifier.md
+└── skills/clean-room-implementation/
+    ├── SKILL.md
+    └── references/artifact-contract.md
+```
+
+## Why state lives outside Git
+
+All case state lives in the user state directory, never inside a repository:
+
+```text
+${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}/<case-id>/
+```
+
+`implementation/source/` is a git worktree (or independent repo), while
+`implementation/.clean-room/` sits beside it — outside the Git tree. That means
+the boundary directory needs no `.gitignore` entry and can never be committed,
+and the observation material can never be pulled into the implementation repo by
+an accidental `git add .`.
+
+## Case layout
+
+```text
+<case-id>/
+├── observation/
+│   ├── target/                  # authorized observable target/material
+│   └── .clean-room/
+│       ├── boundary.md          # observation-only; does not cross the boundary
+│       ├── evidence/            # raw observations (observation-only)
+│       ├── candidate/           # specifier's draft package (no APPROVAL.md)
+│       └── approved/            # human-approved package + APPROVAL.md
+└── implementation/
+    ├── source/                  # git worktree or independent repo
+    └── .clean-room/
+        ├── approved/            # copy of the approved package
+        └── reports/             # conformance.md + audit.md from the verifier
+```
+
+OpenCode runs at `observation/` for the specifier and at `implementation/` for
+the implementer and verifier.
+
+## Workspace commands
+
+The script is portable bash (`set -euo pipefail`) and never overwrites existing
+records.
+
+```sh
+# Create a case. Creates the directory tree and a boundary.md template only if
+# absent. Prints absolute paths and next steps.
+clean-room-workspace.sh init <case-id>
+
+# Print the absolute case root path.
+clean-room-workspace.sh path <case-id>
+
+# Create implementation/source as a git worktree of REPOSITORY on a new branch.
+# Requires an initialized case and an absent-or-empty implementation/source.
+# START_POINT defaults to HEAD.
+clean-room-workspace.sh worktree <case-id> <repository> <branch> [start-point]
+
+# Human approval step (mandatory, outside the agent loop). Copies
+# observation/.clean-room/candidate/ to observation/.clean-room/approved/,
+# generates APPROVAL.md (approver, UTC timestamp, boundary SHA-256, sorted
+# SHA-256 manifest of every other approved file), verifies the digests, then
+# copies the complete package to implementation/.clean-room/approved/.
+# Refuses to overwrite a previous approval; use a new case for a new revision.
+clean-room-workspace.sh approve <case-id> <approver>
+```
+
+`approve` supports either `sha256sum` or macOS `shasum -a 256`. On any failure it
+does not claim approval. Case IDs allow only ASCII letters, digits, `.`, `_`,
+`-` (empty, `.`, and `..` are rejected). `CLEAN_ROOM_STATE_HOME` and
+`XDG_STATE_HOME`, when set, must be absolute paths.
+
+## Installation
+
+Install the skill and the four agents into the OpenCode config:
+
+```sh
+# via the flake (recommended)
+nix run .#install-clean-room-opencode
+
+# directly
+./v2/scripts/clean-room/install-opencode.sh
+```
+
+This symlinks exactly these namespaced paths into
+`${XDG_CONFIG_HOME:-$HOME/.config}/opencode/`:
+
+- `skills/clean-room-implementation` → `v2/scripts/clean-room/skills/clean-room-implementation`
+- `agents/clean-room-orchestrator.md`
+- `agents/clean-room-specifier.md`
+- `agents/clean-room-implementer.md`
+- `agents/clean-room-verifier.md`
+
+Existing symlinks at those paths are replaced; a non-symlink file or directory
+with the same name causes the installer to fail rather than overwrite. Unrelated
+config is never touched. Absolute symlink targets are used so the links stay
+valid regardless of how they are invoked.
+
+When run through the flake app, the installer's asset root is the current
+dotfiles checkout (`$PWD/v2/scripts/clean-room`). This keeps installed symlinks
+stable across Nix garbage collection, so run the command from this repository's
+root. The direct script locates its assets relative to its own path.
+
+**Restart OpenCode** (or reload its config) after installing so the new skill
+and agents are picked up.
+
+Two flake apps are provided in `apps.nix`:
+
+```sh
+nix run .#clean-room-workspace -- init <case-id>
+nix run .#install-clean-room-opencode
+```
+
+## OpenCode model profile
+
+All four agents pin `model: opencode-go/gpt-5.6-luna` and differ only in the
+effort variant and permissions:
+
+| Role | Agent | Mode | Variant |
+| ---- | ----- | ---- | ------- |
+| Coordination | `clean-room-orchestrator` | primary | `high` |
+| Specification | `clean-room-specifier` | all | `max` |
+| Implementation | `clean-room-implementer` | all | `medium` |
+| Verification | `clean-room-verifier` | all | `max` |
+
+Variants (`none`/`low`/`medium`/`high`/`xhigh`/`max`) are provider-specific
+reasoning-effort presets; confirm with `opencode models opencode-go --verbose`.
+
+## Running the phases
+
+Every `opencode run` must use `--interactive` — noninteractive runs auto-reject
+`ask` permissions and silently break the workflow.
+
+```sh
+# 1. Specification (at observation/)
+opencode run --interactive --dir "$CASE/observation" \
+  --agent clean-room-specifier '<specification prompt>'
+
+# 2. Human approval outside the agent loop (not an agent step)
+clean-room-workspace.sh approve "$CASE" '<your name or role>'
+
+# 3. Implementation (at implementation/, fresh session)
+opencode run --interactive --dir "$CASE/implementation" \
+  --agent clean-room-implementer '<implementation prompt>'
+
+# 4. Verification (at implementation/, fresh session)
+opencode run --interactive --dir "$CASE/implementation" \
+  --agent clean-room-verifier '<verification prompt>'
+```
+
+The orchestrator coordinates these sessions; it never runs the phases itself and
+never uses Task subagents for phase work.
+
+## Permission model
+
+| | edit | bash | task | external dir | web |
+| --- | --- | --- | --- | --- | --- |
+| orchestrator | deny | ask | deny | ask | deny |
+| specifier | `evidence/**`, `candidate/**` | ask | deny | deny | ask |
+| implementer | `source/**` only | ask | deny | deny | deny |
+| verifier | `reports/**` only | ask | deny | deny | deny |
+
+These are process controls, not a security sandbox. For enforceable isolation,
+run phases under separate OS users, containers, or machines.
+
+## Caveats
+
+- A `conformant` verification result covers the approved specification package
+  only; it does not prove the specification is complete relative to the target.
+- The specifier labels every requirement `observed`, `documented`, or
+  `inferred`; unknowns stay unresolved rather than guessed.
+- Approval is a human act. Agents cannot create `APPROVAL.md` or write
+  `.clean-room/approved/`.
+- Each revision needs a new case; an existing approval is never overwritten.
+- OpenCode installation links to this checkout. Moving or deleting the checkout
+  requires running the installer again from its new location.
+
+## Legal disclaimer
+
+This workflow is process guidance, not legal advice. Before observing a target,
+confirm the work is authorized and review applicable license, contract,
+anti-circumvention, patent, trademark, privacy, and jurisdiction-specific
+constraints.

--- a/v2/scripts/clean-room/agents/opencode/clean-room-implementer.md
+++ b/v2/scripts/clean-room/agents/opencode/clean-room-implementer.md
@@ -1,0 +1,33 @@
+---
+description: Implements compatible behavior from only an approved clean-room specification package.
+mode: all
+model: opencode-go/gpt-5.6-luna
+variant: medium
+permission:
+  edit:
+    "*": deny
+    "source/**": allow
+  task: deny
+  bash: ask
+  external_directory: deny
+  webfetch: deny
+  websearch: deny
+---
+
+# Clean-room implementer
+
+Load the `clean-room-implementation` skill and perform only its implementation
+phase. Your working directory is the case's implementation directory; your
+working tree is `source/`. You may edit only files under `source/**`.
+
+Before editing, confirm `.clean-room/approved/` contains an `APPROVAL.md` whose
+digests verify against the package files, and that no target source, decompiler
+output, or raw observation evidence is present. Stop and report contamination if
+it is.
+
+Treat `.clean-room/approved/spec.md` as the complete behavioral authority. Do not
+search for the target source, inspect the observation environment, use external
+directories, or infer undocumented behavior merely to make a test pass. Map
+implementation and tests to requirement IDs, run the project's ordinary checks,
+and return ambiguities as requirement-level questions. Never modify the approved
+package or the reports directory.

--- a/v2/scripts/clean-room/agents/opencode/clean-room-orchestrator.md
+++ b/v2/scripts/clean-room/agents/opencode/clean-room-orchestrator.md
@@ -1,0 +1,43 @@
+---
+description: Coordinates clean-room compatibility work across isolated specification, implementation, and verification sessions.
+mode: primary
+model: opencode-go/gpt-5.6-luna
+variant: high
+permission:
+  task: deny
+  edit: deny
+  bash: ask
+  external_directory: ask
+  webfetch: deny
+  websearch: deny
+---
+
+# Clean-room orchestrator
+
+Load the `clean-room-implementation` skill and enforce its invariants.
+
+Coordinate the workflow; do not perform all three roles in this context. Start
+separate `opencode run` processes rooted at the case's observation and
+implementation directories, for example:
+
+```sh
+opencode run --interactive --dir "$CASE/observation" --agent clean-room-specifier 'specify ...'
+opencode run --interactive --dir "$CASE/implementation" --agent clean-room-implementer 'implement ...'
+opencode run --interactive --dir "$CASE/implementation" --agent clean-room-verifier 'verify ...'
+```
+
+Never use Task subagents for phase work: they share this workspace and cannot
+provide the directory isolation the workflow depends on. Always pass
+`--interactive`: noninteractive `opencode run` auto-rejects `ask` permissions,
+which silently breaks this workflow.
+
+Never pass conversation history between roles. Pass only paths and the reviewed
+approved package. Stop for the designated human approver to review
+`.clean-room/candidate/` outside the agent loop; the orchestrator cannot create
+`.clean-room/approved/` or `APPROVAL.md`. Approval is recorded by the human with
+`clean-room-workspace.sh approve <case> <approver>`.
+
+Start the verifier in a fresh session and report any isolation limitation
+explicitly. These permissions are process controls, not a security sandbox;
+recommend OS users, containers, or separate machines when the boundary must be
+enforceable.

--- a/v2/scripts/clean-room/agents/opencode/clean-room-specifier.md
+++ b/v2/scripts/clean-room/agents/opencode/clean-room-specifier.md
@@ -1,0 +1,37 @@
+---
+description: Observes an authorized target and produces a provenance-linked behavioral specification for a clean-room implementer.
+mode: all
+model: opencode-go/gpt-5.6-luna
+variant: max
+permission:
+  edit:
+    "*": deny
+    ".clean-room/evidence/**": allow
+    ".clean-room/candidate/**": allow
+  task: deny
+  bash: ask
+  external_directory: deny
+  webfetch: ask
+  websearch: ask
+---
+
+# Clean-room specifier
+
+Load the `clean-room-implementation` skill and perform only its specification
+phase. Your working directory is the case's observation directory. Work only
+with the observation methods and sources the user has authorized in
+`.clean-room/boundary.md`.
+
+Keep raw observations under `.clean-room/evidence/` and create the candidate
+package under `.clean-room/candidate/` according to the artifact contract
+(`spec.md`, `provenance.md`, `test-vectors.jsonl`, optional `tests/`).
+
+Describe externally observable behavior in original language. Do not copy source
+code, decompiler output, internal names, or unnecessary expressive material into
+the candidate package. Label every requirement `observed`, `documented`, or
+`inferred`; leave unknown behavior unresolved. Use stable requirement IDs and
+link each requirement to the evidence that supports it.
+
+You may draft the candidate package, but you may not approve it, write
+`.clean-room/approved/`, or start implementation. `clean-room-workspace.sh
+approve` is a human-only command.

--- a/v2/scripts/clean-room/agents/opencode/clean-room-verifier.md
+++ b/v2/scripts/clean-room/agents/opencode/clean-room-verifier.md
@@ -1,0 +1,31 @@
+---
+description: Verifies an independent implementation against its approved clean-room specification from a fresh context.
+mode: all
+model: opencode-go/gpt-5.6-luna
+variant: max
+permission:
+  edit:
+    "*": deny
+    ".clean-room/reports/**": allow
+  task: deny
+  bash: ask
+  external_directory: deny
+  webfetch: deny
+  websearch: deny
+---
+
+# Clean-room verifier
+
+Load the `clean-room-implementation` skill and perform only its verification
+phase. Your working directory is the case's implementation directory and must
+contain the independent implementation and `.clean-room/approved/`, but no raw
+observation evidence. Stop and report contamination if the boundary is not
+satisfied.
+
+Do not edit implementation code or the approved package. Check every normative
+requirement, run the available conformance and project tests, and ground every
+progress or pass claim in a tool result from this session. Write
+`.clean-room/reports/conformance.md` and `.clean-room/reports/audit.md` according
+to the artifact contract. Use `inconclusive`, not `conformant`, when required
+evidence is missing. A `conformant` result covers the approved specification
+only, not the completeness of that specification relative to the target.

--- a/v2/scripts/clean-room/clean-room-workspace.sh
+++ b/v2/scripts/clean-room/clean-room-workspace.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# clean-room-workspace.sh — manage isolated clean-room case directories.
+#
+# A case lives OUTSIDE any Git repository, under
+#   ${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}/<case-id>/
+# so that .clean-room/ never needs a .gitignore entry and the boundary between
+# observation and implementation stays outside the implementation's Git tree.
+#
+# Commands:
+#   init CASE                  create the case directory structure and boundary template
+#   path CASE                  print the absolute case root path
+#   worktree CASE REPO BRANCH [START_POINT]
+#                              create implementation/source as a git worktree
+#   approve CASE APPROVER      record human approval of the candidate package
+#   help                       show usage
+#
+# `approve` is the only command that writes an approved package, and it is
+# intentionally a human-invoked command. Agents must never run it.
+
+set -euo pipefail
+: "${HOME:?HOME must be set}"
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+die() {
+  printf 'clean-room-workspace: error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: clean-room-workspace.sh <command> [args...]
+
+Commands:
+  init CASE                 Create a new clean-room case directory structure
+                            and a boundary.md template. Never overwrites
+                            existing records.
+  path CASE                 Print the absolute case root path.
+  worktree CASE REPO BRANCH [START_POINT]
+                            Create implementation/source as a git worktree of
+                            REPO on a new branch BRANCH. START_POINT defaults
+                            to HEAD. Requires an initialized case and an
+                            absent-or-empty implementation/source.
+  approve CASE APPROVER     Record human approval of the candidate package:
+                            copy candidate -> observation/.clean-room/approved,
+                            generate APPROVAL.md (approver, UTC timestamp,
+                            boundary SHA-256, sorted package manifest), verify
+                            the digests, then copy the complete package to
+                            implementation/.clean-room/approved. Fails rather
+                            than overwriting a previous approval.
+
+Environment:
+  CLEAN_ROOM_STATE_HOME      Override the state base directory. Default:
+                             ${XDG_STATE_HOME:-$HOME/.local/state}/clean-room
+EOF
+}
+
+state_root() {
+  local root="${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}"
+  case "$root" in
+    /*) ;;
+    *) die "clean-room state root must be an absolute path: $root" ;;
+  esac
+  printf '%s\n' "$root"
+}
+
+validate_case_id() {
+  local case_id="$1"
+  [ -n "$case_id" ] || die "case id is required"
+  case "$case_id" in
+    . | ..)
+      die "invalid case id: '$case_id'"
+      ;;
+  esac
+  if [[ ! "$case_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    die "invalid case id '$case_id': only ASCII letters, digits, '.', '_', '-' are allowed"
+  fi
+}
+
+case_root() {
+  local case_id="$1"
+  validate_case_id "$case_id"
+  printf '%s/%s\n' "$(state_root)" "$case_id"
+}
+
+require_case() {
+  local case_id="$1"
+  local root
+  root="$(case_root "$case_id")"
+  if [ ! -f "$root/observation/.clean-room/boundary.md" ]; then
+    die "case '$case_id' is not initialized (missing $root/observation/.clean-room/boundary.md); run 'init $case_id' first"
+  fi
+  printf '%s\n' "$root"
+}
+
+# dir_is_empty DIR: true when DIR is missing or has no entries.
+dir_is_empty() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+  [ -z "$(ls -A "$dir" 2>/dev/null)" ]
+}
+
+# ensure_dir_empty DIR LABEL: create if missing, fail if non-empty.
+ensure_dir_empty() {
+  local dir="$1" label="$2"
+  [ ! -L "$dir" ] || die "$label must not be a symlink: $dir"
+  mkdir -p "$dir"
+  if ! dir_is_empty "$dir"; then
+    die "$label is not empty: $dir — a previous approval exists. Use a new case for a new revision."
+  fi
+}
+
+# sha256_digest FILE: print the lowercase hex SHA-256 digest of FILE.
+# Supports sha256sum (GNU coreutils) and shasum -a 256 (macOS).
+sha256_digest() {
+  local file="$1" out
+  if command -v sha256sum >/dev/null 2>&1; then
+    out="$(sha256sum "$file")" || return 1
+  elif command -v shasum >/dev/null 2>&1; then
+    out="$(shasum -a 256 "$file")" || return 1
+  else
+    printf 'clean-room-workspace: error: no SHA-256 tool found (need sha256sum or shasum)\n' >&2
+    return 1
+  fi
+  printf '%s\n' "${out%% *}"
+}
+
+# generate_manifest DIR: sorted '<hash>  <relative-path>' lines for every file
+# in DIR except APPROVAL.md. Paths are relative to DIR and sorted by path.
+generate_manifest() {
+  local dir="$1" f h
+  (
+    cd "$dir" || return 1
+    find . -type f ! -path ./APPROVAL.md -print | LC_ALL=C sort |
+      while IFS= read -r f; do
+        h="$(sha256_digest "${f#./}")" || {
+          printf 'clean-room-workspace: error: failed to hash %s\n' "${f#./}" >&2
+          exit 1
+        }
+        printf '%s  %s\n' "$h" "${f#./}"
+      done
+  )
+}
+
+# Staging cleanup: remove any leftover staging dirs if the script exits early.
+# A successful approve clears the array so moved packages are never deleted.
+STAGING_PATHS=()
+cleanup_staging() {
+  local staging
+  for staging in "${STAGING_PATHS[@]}"; do
+    [ -d "$staging" ] && rm -rf "$staging"
+  done
+}
+trap cleanup_staging EXIT
+
+# ---------------------------------------------------------------------------
+# init CASE
+# ---------------------------------------------------------------------------
+
+cmd_init() {
+  local case_id="${1:-}"
+  validate_case_id "$case_id"
+  local root
+  root="$(case_root "$case_id")"
+
+  local obs="$root/observation/.clean-room"
+  local impl="$root/implementation/.clean-room"
+
+  mkdir -p "$root/observation/target"
+  mkdir -p "$obs/evidence" "$obs/candidate" "$obs/approved"
+  mkdir -p "$impl/approved" "$impl/reports"
+
+  local boundary="$obs/boundary.md"
+  if [ -e "$boundary" ]; then
+    printf 'kept existing %s\n' "$boundary"
+  else
+    cat >"$boundary" <<EOF
+# Clean-room boundary
+
+Case: $case_id
+Created (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+## Target and compatibility goal
+
+- Target:
+- Compatibility goal:
+
+## Observation
+
+- Observation directory: $root/observation/
+- Permitted observation methods:
+- Prohibited materials (never put these in the approved package):
+  - target source code
+  - decompiler output
+  - raw observation logs or evidence
+  - unapproved third-party material
+
+## Implementation
+
+- Implementation directory: $root/implementation/
+- Implementation source: $root/implementation/source/
+
+## Scope
+
+- Public interfaces in scope:
+- Acceptance criteria:
+- Non-goals:
+
+## Approval
+
+- Designated approver (human, outside the agent loop):
+- Approved (UTC):
+
+## Legal note
+
+This workflow is process guidance, not legal advice. Confirm that observing
+the target is authorized and review applicable license, contract,
+anti-circumvention, patent, trademark, privacy, and jurisdiction-specific
+constraints.
+EOF
+    printf 'created %s\n' "$boundary"
+  fi
+
+  printf '\nClean-room case %q initialized.\n' "$case_id"
+  printf '  observation:    %s\n' "$root/observation"
+  printf '  implementation: %s\n' "$root/implementation"
+  printf '\nNext steps:\n'
+  printf '  1. Edit %s to record the boundary.\n' "$boundary"
+  printf '  2. Place authorized observable material under %s.\n' "$root/observation/target"
+  printf '  3. Run: clean-room-workspace.sh worktree %s <repo> <branch>\n' "$case_id"
+  printf '  4. After the specifier drafts a candidate, review it and run:\n'
+  printf '     clean-room-workspace.sh approve %s <approver>\n' "$case_id"
+}
+
+# ---------------------------------------------------------------------------
+# path CASE
+# ---------------------------------------------------------------------------
+
+cmd_path() {
+  local case_id="${1:-}"
+  printf '%s\n' "$(case_root "$case_id")"
+}
+
+# ---------------------------------------------------------------------------
+# worktree CASE REPOSITORY BRANCH [START_POINT]
+# ---------------------------------------------------------------------------
+
+cmd_worktree() {
+  local case_id="${1:-}" repository="${2:-}" branch="${3:-}" start_point="${4:-}"
+  validate_case_id "$case_id"
+  [ -n "$repository" ] || die "repository path is required"
+  [ -n "$branch" ] || die "branch name is required"
+  git -C "$repository" check-ref-format --branch "$branch" >/dev/null 2>&1 ||
+    die "invalid branch name: $branch"
+  local root
+  root="$(require_case "$case_id")"
+
+  local source_dir="$root/implementation/source"
+  if [ -e "$source_dir" ] && ! dir_is_empty "$source_dir"; then
+    die "implementation/source exists and is not empty: $source_dir (refusing to overwrite)"
+  fi
+
+  local commit
+  commit="$(git -C "$repository" rev-parse --verify "${start_point:-HEAD}^{commit}")" ||
+    die "invalid start point: ${start_point:-HEAD}"
+  git -C "$repository" worktree add -b "$branch" "$source_dir" "$commit"
+  printf 'worktree added: %s (branch %s)\n' "$source_dir" "$branch"
+}
+
+# ---------------------------------------------------------------------------
+# approve CASE APPROVER
+# ---------------------------------------------------------------------------
+
+verify_approval() {
+  local dir="$1" boundary="$2" expected_boundary="$3" approval_file="$4"
+  local manifest recorded boundary_recorded actual_boundary
+
+  manifest="$(generate_manifest "$dir")" || die "approval verification failed: could not recompute package manifest"
+  recorded="$(grep -E '^[0-9a-f]{64}  ' "$approval_file")" || true
+  if [ "$manifest" != "$recorded" ]; then
+    die "approval verification failed: recomputed package digests do not match APPROVAL.md"
+  fi
+
+  boundary_recorded="$(sed -n 's/^- Boundary SHA-256: //p' "$approval_file")"
+  actual_boundary="$(sha256_digest "$boundary")" || die "approval verification failed: could not recompute boundary digest"
+  if [ "$boundary_recorded" != "$expected_boundary" ] || [ "$boundary_recorded" != "$actual_boundary" ]; then
+    die "approval verification failed: boundary SHA-256 mismatch"
+  fi
+}
+
+cmd_approve() {
+  local case_id="${1:-}" approver="${2:-}"
+  validate_case_id "$case_id"
+  [ -n "$approver" ] || die "approver is required (usage: approve CASE APPROVER)"
+  case "$approver" in
+    *$'\n'* | *$'\r'*) die "approver must be a single line" ;;
+  esac
+  local root
+  root="$(require_case "$case_id")"
+
+  local obs="$root/observation/.clean-room"
+  local impl="$root/implementation/.clean-room"
+  local candidate="$obs/candidate"
+  local obs_approved="$obs/approved"
+  local impl_approved="$impl/approved"
+  local boundary="$obs/boundary.md"
+
+  # Candidate prerequisites
+  [ -f "$candidate/spec.md" ] || die "candidate is missing spec.md: $candidate/spec.md"
+  [ -f "$candidate/provenance.md" ] || die "candidate is missing provenance.md: $candidate/provenance.md"
+  [ -f "$candidate/test-vectors.jsonl" ] || die "candidate is missing test-vectors.jsonl: $candidate/test-vectors.jsonl"
+  if [ -e "$candidate/APPROVAL.md" ]; then
+    die "candidate contains APPROVAL.md; a candidate cannot approve itself — remove it and re-run approve"
+  fi
+
+  # Never overwrite a previous approval: both approved dirs must be empty.
+  ensure_dir_empty "$obs_approved" "observation .clean-room/approved"
+  ensure_dir_empty "$impl_approved" "implementation .clean-room/approved"
+
+  # Stage and verify both copies before publishing either package.
+  local staging
+  staging="$(mktemp -d "$root/.approve-staging.XXXXXX")" || die "failed to create staging directory"
+  STAGING_PATHS+=("$staging")
+  cp -a "$candidate/." "$staging/"
+
+  local now boundary_hash manifest
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  boundary_hash="$(sha256_digest "$boundary")" || die "failed to hash boundary file"
+  manifest="$(generate_manifest "$staging")" || die "failed to compute package manifest"
+
+  cat >"$staging/APPROVAL.md" <<EOF
+# Clean-room approval record
+
+- Case: $case_id
+- Approver: $approver
+- Approved (UTC): $now
+- Boundary file: observation/.clean-room/boundary.md
+- Boundary SHA-256: $boundary_hash
+
+## SHA-256 manifest
+
+Sorted SHA-256 digest of every other file in this package, relative to this
+directory. Do not modify this package after approval; create a new case for a
+new revision.
+
+$manifest
+EOF
+
+  # Verify the recorded digests against the actual files before declaring approval.
+  verify_approval "$staging" "$boundary" "$boundary_hash" "$staging/APPROVAL.md"
+
+  # Prepare and verify the implementation copy before publishing either package.
+  local impl_staging
+  impl_staging="$(mktemp -d "$impl/.impl-staging.XXXXXX")" || die "failed to create implementation staging directory"
+  STAGING_PATHS+=("$impl_staging")
+  cp -a "$staging/." "$impl_staging/"
+  verify_approval "$impl_staging" "$boundary" "$boundary_hash" "$impl_staging/APPROVAL.md"
+
+  # Publish both verified packages. The target directories are known empty.
+  rmdir "$obs_approved"
+  rmdir "$impl_approved"
+  if ! mv "$staging" "$obs_approved"; then
+    mkdir -p "$obs_approved" "$impl_approved"
+    die "failed to publish the observation package"
+  fi
+  if ! mv "$impl_staging" "$impl_approved"; then
+    # Restore the pre-approval state so the human can safely retry.
+    mv "$obs_approved" "$staging" ||
+      die "failed to publish the implementation package and could not roll back the observation package"
+    mkdir -p "$obs_approved" "$impl_approved"
+    die "failed to publish the implementation package; approval was rolled back"
+  fi
+  STAGING_PATHS=()
+
+  printf '\nApproval recorded.\n'
+  printf '  approver:            %s\n' "$approver"
+  printf '  approved (UTC):      %s\n' "$now"
+  printf '  observation package: %s\n' "$obs_approved"
+  printf '  implementation pkg:  %s\n' "$impl_approved"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  local command="${1:-}"
+  case "$command" in
+    init)
+      cmd_init "${2:-}"
+      ;;
+    path)
+      cmd_path "${2:-}"
+      ;;
+    worktree)
+      cmd_worktree "${2:-}" "${3:-}" "${4:-}" "${5:-}"
+      ;;
+    approve)
+      cmd_approve "${2:-}" "${3:-}"
+      ;;
+    help | -h | --help)
+      usage
+      ;;
+    "")
+      usage >&2
+      exit 1
+      ;;
+    *)
+      usage >&2
+      die "unknown command: $command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/v2/scripts/clean-room/install-opencode.sh
+++ b/v2/scripts/clean-room/install-opencode.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# install-opencode.sh — symlink the clean-room skill and agents into the
+# OpenCode configuration so `opencode` can load them.
+#
+# Installs exactly these namespaced links (and nothing else):
+#   ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills/clean-room-implementation
+#   ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/agents/clean-room-{orchestrator,specifier,implementer,verifier}.md
+#
+# - Replaces an existing symlink at the same path.
+# - Fails rather than overwriting a non-symlink file or directory.
+# - Never deletes unrelated configuration.
+# - Uses absolute symlink targets, so the links stay valid no matter how the
+#   script or the OpenCode config is invoked.
+
+set -euo pipefail
+: "${HOME:?HOME must be set}"
+
+# Resolve this script's real directory, handling invocation through a symlink.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  case "$SOURCE" in
+    /*) ;;
+    *) SOURCE="$DIR/$SOURCE" ;;
+  esac
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+# The assets (skills/, agents/) normally live next to this script. The flake app
+# injects the current dotfiles checkout via CLEAN_ROOM_SOURCE_DIR so installed
+# links do not point at an unrooted, garbage-collectable Nix store path.
+BASE_DIR="${CLEAN_ROOM_SOURCE_DIR:-$SCRIPT_DIR}"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
+SKILLS_DIR="$CONFIG_DIR/skills"
+AGENTS_DIR="$CONFIG_DIR/agents"
+
+SOURCE_SKILL="$BASE_DIR/skills/clean-room-implementation"
+SKILL_LINK="$SKILLS_DIR/clean-room-implementation"
+
+AGENT_SOURCES=(
+  "$BASE_DIR/agents/opencode/clean-room-orchestrator.md"
+  "$BASE_DIR/agents/opencode/clean-room-specifier.md"
+  "$BASE_DIR/agents/opencode/clean-room-implementer.md"
+  "$BASE_DIR/agents/opencode/clean-room-verifier.md"
+)
+
+install_link() {
+  local source="$1" link="$2"
+  if [ ! -e "$source" ]; then
+    printf 'install-opencode: error: source does not exist: %s\n' "$source" >&2
+    exit 1
+  fi
+  if [ -L "$link" ]; then
+    rm -f "$link" # replace our own (or any) symlink, broken or not
+  elif [ -e "$link" ]; then
+    printf 'install-opencode: error: %s exists and is not a symlink; refusing to overwrite\n' "$link" >&2
+    exit 1
+  fi
+  ln -s "$source" "$link"
+  printf 'linked %s -> %s\n' "$link" "$source"
+}
+
+mkdir -p "$SKILLS_DIR" "$AGENTS_DIR"
+
+install_link "$SOURCE_SKILL" "$SKILL_LINK"
+for agent in "${AGENT_SOURCES[@]}"; do
+  install_link "$agent" "$AGENTS_DIR/$(basename "$agent")"
+done
+
+printf '\nInstalled the clean-room skill and four agents into %s.\n' "$CONFIG_DIR"
+printf 'Restart OpenCode (or reload its config) so the new skill and agents are picked up.\n'

--- a/v2/scripts/clean-room/skills/clean-room-implementation/SKILL.md
+++ b/v2/scripts/clean-room/skills/clean-room-implementation/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: clean-room-implementation
+description: Coordinate clean-room or black-box compatibility implementation through separated specification, implementation, and conformance agents. Use when building an emulator, compatible replacement, protocol implementation, file-format reader, API clone, or other interoperability work where the implementer must receive only an approved behavioral specification.
+compatibility: OpenCode; OpenCode agents use opencode-go/gpt-5.6-luna.
+---
+
+# Clean-room implementation
+
+Separate observation from implementation. The deliverable is not just compatible
+code: it is a traceable handoff showing what the implementer received and how the
+verifier checked it.
+
+This workflow is process guidance, not legal advice. Before observing a target,
+establish that the work is authorized and identify relevant license, contract,
+anti-circumvention, patent, trademark, privacy, and jurisdiction-specific
+constraints. Stop when authorization or the permitted observation methods are
+unclear.
+
+Read [`references/artifact-contract.md`](references/artifact-contract.md) before
+starting.
+
+## Case workspace
+
+Every case lives OUTSIDE any Git repository, under:
+
+```text
+${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}/<case-id>/
+```
+
+```text
+<case-id>/
+├── observation/
+│   ├── target/                  # authorized observable target/material
+│   └── .clean-room/
+│       ├── boundary.md
+│       ├── evidence/
+│       ├── candidate/
+│       └── approved/
+└── implementation/
+    ├── source/                  # git worktree or independent repo
+    └── .clean-room/
+        ├── approved/
+        └── reports/
+```
+
+- The specifier runs at `observation/`; the implementer and verifier run at
+  `implementation/`.
+- `.clean-room/` sits outside `implementation/source/`'s Git tree, so no
+  `.gitignore` entry is ever needed for it.
+- Manage cases with `clean-room-workspace.sh` (`init`, `path`, `worktree`,
+  `approve`). See the README in `v2/scripts/clean-room/` for usage.
+
+## Invariants
+
+- Keep the observable target inside the observation directory; phase agents
+  cannot access external directories.
+- Use separate observation and implementation directories that are not nested
+  inside each other.
+- Never give the implementer target source, decompiler output, raw observation
+  logs, or conversation history from the specification phase.
+- Move only the reviewed `.clean-room/approved/` package across the boundary.
+- Start the implementer and verifier in fresh sessions. Never continue or fork
+  the specifier session.
+- Treat model separation as process discipline, not a security boundary. Use
+  OS-level isolation when the boundary must be enforceable.
+- Keep observed behavior, public documentation, and inference distinguishable.
+- Do not claim legal cleanliness or conformance merely because the workflow
+  completed.
+
+## OpenCode model profile
+
+OpenCode Go currently exposes GPT through `opencode-go/gpt-5.6-luna`. Use model
+variants to allocate effort:
+
+| Role | Agent | Variant |
+| ---- | ----- | ------- |
+| Coordination | `clean-room-orchestrator` | `high` |
+| Specification | `clean-room-specifier` | `max` |
+| Implementation | `clean-room-implementer` | `medium` |
+| Verification | `clean-room-verifier` | `max` |
+
+Do not silently substitute another provider or model. If the configured model is
+unavailable, report the blocker and let the user select a replacement.
+
+Every `opencode run` invocation must pass `--interactive`: noninteractive runs
+auto-reject `ask` permissions and break the workflow silently.
+
+## 1. Establish the boundary
+
+Write `observation/.clean-room/boundary.md` and record:
+
+- the target and compatibility goal;
+- permitted observation methods and prohibited materials;
+- the observation directory and independent implementation directory;
+- the public interfaces in scope;
+- acceptance criteria and non-goals;
+- who approves the specification package.
+
+The implementation directory must not contain or reference the observation
+directory. Check both trees before implementation begins. If this cannot be
+established, stop rather than calling the process clean-room.
+
+## 2. Specify in the observation environment
+
+Run `clean-room-specifier` in a fresh session rooted at `observation/`:
+
+```sh
+opencode run --interactive --dir "$CASE/observation" --agent clean-room-specifier '...'
+```
+
+It may inspect only materials allowed by the recorded boundary. It writes raw
+material to `.clean-room/evidence/` and the candidate handoff to
+`.clean-room/candidate/`.
+
+Require:
+
+- stable requirement identifiers;
+- reproducible experiments and exact results;
+- positive, negative, boundary, and state-transition behavior;
+- explicit uncertainty instead of guessed behavior;
+- original behavioral descriptions rather than copied implementation expression;
+- provenance linking each requirement to evidence.
+
+Have the designated human approver review the candidate outside the agent loop
+before crossing the boundary. The approver removes unnecessary expressive
+material and anything whose use was not approved, then records approval with a
+human-only command:
+
+```sh
+clean-room-workspace.sh approve <case-id> <approver>
+```
+
+`approve` copies the candidate to `observation/.clean-room/approved/`, generates
+`APPROVAL.md` (approver, UTC timestamp, boundary SHA-256, sorted package
+manifest), verifies the digests, and copies the complete package to
+`implementation/.clean-room/approved/`. Neither the specifier nor the
+orchestrator can approve the draft.
+
+## 3. Implement in an isolated fresh session
+
+The approved package now lives in `implementation/.clean-room/approved/`. Start
+`clean-room-implementer` there with a new context:
+
+```sh
+opencode run --interactive --dir "$CASE/implementation" --agent clean-room-implementer '...'
+```
+
+Its task prompt may contain the compatibility goal, approved-package path,
+implementation constraints, and completion criteria. It must not contain a
+summary of observation-only material.
+
+The implementer:
+
+- maps code and tests to requirement identifiers;
+- implements only specified behavior;
+- records ambiguities as questions against requirement identifiers;
+- does not search for the target source or undocumented internals;
+- does not invent behavior to make tests pass;
+- runs the implementation project's ordinary tests and reports exact outcomes.
+
+Questions cross back as requirement-level questions. The specifier may update the
+candidate package, but the answer must not include raw evidence or internal
+implementation detail. The designated approver must review and approve a new
+package revision. Start a new implementation session after a material
+specification update.
+
+## 4. Verify from a fresh context
+
+Start `clean-room-verifier` in a new session rooted at `implementation/`:
+
+```sh
+opencode run --interactive --dir "$CASE/implementation" --agent clean-room-verifier '...'
+```
+
+Give it the approved package and independent implementation, but no observation
+session or raw evidence.
+
+The verifier:
+
+- checks every normative requirement;
+- runs approved conformance tests and relevant project tests;
+- cites command results from its own session;
+- distinguishes failures from checks that could not be performed;
+- writes `.clean-room/reports/conformance.md` using the artifact contract;
+- does not edit implementation code.
+
+For failures, return only the requirement identifier, expected behavior,
+observed implementation behavior, and reproduction command to the implementer.
+Repeat implementation and fresh verification until conformant or explicitly
+stopped. Never weaken the specification solely to accept the current
+implementation.
+
+## 5. Finish with an audit summary
+
+Write `.clean-room/reports/audit.md` and report:
+
+- approved-package revision or digest;
+- implementation revision;
+- conformance result;
+- unresolved requirements and legal/process caveats;
+- where observation-only evidence and implementation artifacts reside;
+- confirmation that only the approved package crossed the boundary, or an
+  explicit disclosure that the invariant was not verified.
+
+State that a `conformant` result covers the approved specification only and does
+not independently prove that the specification is complete relative to the
+target.

--- a/v2/scripts/clean-room/skills/clean-room-implementation/references/artifact-contract.md
+++ b/v2/scripts/clean-room/skills/clean-room-implementation/references/artifact-contract.md
@@ -1,0 +1,133 @@
+# Clean-room artifact contract
+
+Only the independently reviewed approved package crosses from the observation
+environment to the implementation environment. Paths below are relative to the
+case root:
+
+```text
+${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}/<case-id>/
+```
+
+## Boundary record
+
+Store `observation/.clean-room/boundary.md`. Record the target, compatibility
+goal, permitted observation methods, prohibited materials, directories,
+interfaces in scope, acceptance criteria, non-goals, and designated approver.
+This file is observation-only and does not cross the boundary.
+
+## Observation-only artifacts
+
+Store these under `observation/.clean-room/evidence/`. Never copy them into the
+implementation environment.
+
+- Experiment commands and raw outputs.
+- Packet captures, traces, screenshots, and target-generated files.
+- Notes about public documentation and the exact source consulted.
+- Rejected hypotheses and exploratory observations.
+- Any material whose redistribution or use has not been approved.
+
+## Candidate package
+
+The specifier writes `observation/.clean-room/candidate/` using the
+approved-package layout below except for `APPROVAL.md`. The specifier cannot
+write `observation/.clean-room/approved/` and cannot approve its own candidate.
+
+## Approved package
+
+Store the reviewed package under `observation/.clean-room/approved/` and its copy
+under `implementation/.clean-room/approved/`:
+
+```text
+.clean-room/approved/
+├── spec.md
+├── provenance.md
+├── test-vectors.jsonl
+├── APPROVAL.md
+└── tests/                  # optional executable conformance tests
+```
+
+A designated human approver reviews the candidate outside the agent loop, removes
+material that must not cross the boundary, and records approval with
+`clean-room-workspace.sh approve <case-id> <approver>`. The command copies the
+candidate into `observation/.clean-room/approved/`, generates `APPROVAL.md`
+recording:
+
+- approver identity or role;
+- approval timestamp (UTC);
+- SHA-256 of `observation/.clean-room/boundary.md`;
+- a sorted SHA-256 manifest of every other file in the package;
+
+verifies those digests, and then copies the complete package to
+`implementation/.clean-room/approved/`. The package is not approved when
+`APPROVAL.md` is missing or its digests do not match. A previous approval is
+never overwritten; create a new case for a new revision.
+
+### `spec.md`
+
+Every normative requirement has a stable identifier such as `CR-INPUT-001`. For
+each requirement, record:
+
+- externally observable behavior;
+- preconditions and inputs;
+- outputs, state changes, and errors;
+- whether it is observed, documented, or inferred;
+- the evidence identifier supporting it;
+- unresolved ambiguity.
+
+Describe behavior in original language. Do not include source code, decompiler
+output, copied internal names, or expressive material that is unnecessary for
+compatibility.
+
+### `provenance.md`
+
+List the origin of every source used to derive the approved package and the
+authorization or permission status supplied by the user or reviewer. Do not make
+an independent legal determination. Link each entry to the requirement
+identifiers it supports. Record public documentation quotations only when
+necessary and keep them clearly attributed; prefer an original behavioral
+description.
+
+### `test-vectors.jsonl`
+
+Use one JSON object per line:
+
+```json
+{"id":"CR-TV-001","requirements":["CR-INPUT-001"],"input":{},"expected":{},"comparison":"exact"}
+```
+
+Keep observed values exact. Mark unstable or environment-dependent fields
+explicitly instead of guessing normalized values.
+
+### `tests/`
+
+Executable tests must exercise only the public behavior described by `spec.md`.
+They must not expose or read observation-only artifacts at runtime.
+
+## Implementation artifacts
+
+The implementation environment may contain the approved package, independent
+source code, build outputs, and `.clean-room/reports/`. It must not contain the
+target source, decompiler output, or raw observation evidence.
+
+## Conformance report
+
+Write `implementation/.clean-room/reports/conformance.md` with:
+
+- the implementation revision tested;
+- the approved-package digest or revision;
+- commands actually run and their outcomes;
+- one result per requirement identifier;
+- divergences, missing evidence, and blocked checks;
+- a final `conformant`, `non-conformant`, or `inconclusive` result.
+
+Never report a check as passing unless a tool result from the current verifier
+session supports it. `Conformant` means conformant to the approved specification
+package only; it is not an independent claim that the specification fully
+represents the target.
+
+## Audit summary
+
+Write `implementation/.clean-room/reports/audit.md` after verification. Include
+the approved-package digests, implementation revision, conformance result and
+its scope, unresolved items, process caveats, artifact locations, and whether the
+package boundary was verified.


### PR DESCRIPTION
## Summary

- move the clean-room compatibility workflow into the development tooling repository
- keep all case state under `${CLEAN_ROOM_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/clean-room}/<case-id>/`, outside Git repositories
- add workspace lifecycle commands for initialization, Git worktrees, human approval, and SHA-256 manifests
- add OpenCode Go GPT-5.6 Luna agents for orchestration, specification, implementation, and verification
- add flake apps for workspace management and OpenCode installation

## Verification

- `bash -n` for both scripts
- `nix flake check --no-update-lock-file`
- `nix run nixpkgs#nixfmt -- --check apps.nix`
- temporary XDG state functional tests for init, path, worktree, approval, nested manifest files, invalid branches, and refusal of relative state paths
- temporary XDG config tests for installer links, Agent discovery, and non-symlink collision safety
- Nix app end-to-end tests for workspace initialization and OpenCode installation

## Related

This supersedes the initial implementation proposed in `ttak0422/track-lab#16`.