### PR TITLE
fix(pterm): use binary cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -922,11 +922,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1787969196,
-        "narHash": "sha256-xFFM7GTWClJAckstPJsUXIZdZBITpQXRC1WbnkoD2Ng=",
+        "lastModified": 1788074786,
+        "narHash": "sha256-mBW7j8mXHoqalOFwy5yz3kgnXqrsIJomTj6kjeW2vWE=",
         "owner": "ttak0422",
         "repo": "pterm",
-        "rev": "f9b7e2f0d5c944ae08504cdf01e8b527abc8efc7",
+        "rev": "6330f6929f49f965f35bce87dc2163de31e59f58",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -465,11 +465,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1770841267,
-        "narHash": "sha256-9xejG0KoqsoKEGp2kVbXRlEYtFFcDTHjidiuX8hGO44=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec7c70d12ce2fc37cb92aff673dcdca89d187bae",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -922,11 +922,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1788074786,
-        "narHash": "sha256-mBW7j8mXHoqalOFwy5yz3kgnXqrsIJomTj6kjeW2vWE=",
+        "lastModified": 1788075295,
+        "narHash": "sha256-53UmPGBVYyXNYDaz6HPaFaGnOUiHPnVL3QklGG3G8YI=",
         "owner": "ttak0422",
         "repo": "pterm",
-        "rev": "6330f6929f49f965f35bce87dc2163de31e59f58",
+        "rev": "1567f20468b1b3e5f60886f67791199b9e71e66a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -922,11 +922,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1787158333,
-        "narHash": "sha256-/25rEb/rtsKxYnXXcn4BR/A/9fBJY95I4dPguRbgEv0=",
+        "lastModified": 1787969196,
+        "narHash": "sha256-xFFM7GTWClJAckstPJsUXIZdZBITpQXRC1WbnkoD2Ng=",
         "owner": "ttak0422",
         "repo": "pterm",
-        "rev": "6b26fc218dda6f06c1e17dd8fb0f093579ab547b",
+        "rev": "f9b7e2f0d5c944ae08504cdf01e8b527abc8efc7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,12 @@
     extra-substituters = [
       "https://nix-community.cachix.org"
       "https://ttak0422.cachix.org"
+      "https://ttak0422-pterm.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "ttak0422.cachix.org-1:8+SW9jr2e4ieB9eaXAiuoS2wKnTqiMf30XdOi6hTIu8="
+      "ttak0422-pterm.cachix.org-1:s0zSh4J7l8NrisVESCYNxcSw7rz2vLsGa5fh+E42NDY="
     ];
     extra-experimental-features = "nix-command flakes";
   };


### PR DESCRIPTION
## Summary
- Add the pterm Cachix substituter and signing key
- Update `v2-pterm` to the pterm build-fix merge revision
- Update the locked pterm `naersk` and `nixpkgs` inputs through the pterm flake

This depends on ttak0422/pterm#79, which updates `naersk` to use `static.crates.io` and publishes the successful `aarch64-darwin` build to Cachix.

Build locally with:

```sh
nix build --accept-flake-config .#bundler-nvim-v2
```